### PR TITLE
Problem: char does not fit into the Unicode nomenclature

### DIFF
--- a/1/README.md
+++ b/1/README.md
@@ -76,27 +76,23 @@ ByteArray is an array of bytes.
 
 Default value: empty array.
 
-### 1.10. Character
-
-Default value: `0x0000` (16-bit entity)
-
-### 1.11. String
+### 1.10. String
 
 UTF-8 string.
 
 Default value: empty string
 
-### 1.12. UUID
+### 1.11. UUID
 
 Default value: `00000000-0000-0000-0000-000000000000`
 
-### 1.13. List
+### 1.12. List
 
 List is a parametrized type and can take any other type as a parameter.
 
 Default value: empty list
 
-### 1.14. Optional
+### 1.13. Optional
 
 Optional is a type that signifies a value that might be either present or not.
 
@@ -104,7 +100,7 @@ Optional is a parametrized type and can take any other type as a parameter.
 
 Default value: value not present
 
-### 1.15. Enum
+### 1.14. Enum
 
 Enum represents a type with a closed set of possible ordinal (integer) values (for example, `OPEN = 0, CLOSED = 1`). The ordinal values MUST start with 0
 and form a consecutive sequence.
@@ -131,7 +127,6 @@ It is RECOMMENDED that a human readable, latin1 encoded name is specified for ty
 | Double      | 0x446f75626c65                | Double                        |
 | Byte        | 0x42797465                    | Byte                          |
 | ByteArray   | 0x427974654172726179          | ByteArray                     |
-| Character   | 0x436861726163746572          | Character                     |
 | String      | 0x537472696e67                | String                        |
 | UUID        | 0x55554944                    | UUID                          |
 | List        | 0x4c6973745b + ? + 5d         | List[?]                       |

--- a/2/README.md
+++ b/2/README.md
@@ -107,19 +107,7 @@ ByteArray serialization is of a variable size.
 | 0              |  4             | *len* = number of bytes    |
 | 4              |  *len*         | bytes                      |
 
-### 1.10. Character
-
-The serialization format is based on the original Unicode specification, which defined characters as fixed-width 16-bit entities. Even though it is an outdated
-representation superseded by newer Unicode standards, this format is kept
-in the sake of simplifying usage of languages that still use this representation.
-
-Character serialization is always of a constant size (2 bytes).
-
-| Offset (bytes) | Length (bytes) | Value                      |
-|----------------|----------------|----------------------------|
-| 0              |  2             | character value            |
-
-### 1.11. String
+### 1.10. String
 
 String serialization is of variable size.
 
@@ -128,7 +116,7 @@ String serialization is of variable size.
 | 0              |  4             | *len* = string size in bytes |
 | 4              |  *len*         | UTF-8 encoded string         |
 
-### 1.12. UUID
+### 1.11. UUID
 
 UUID serialization is always of a constant size (16 bytes)
 
@@ -137,7 +125,7 @@ UUID serialization is always of a constant size (16 bytes)
 | 0              |  8             | most significant bytes       |
 | 8              |  8             | least significant bytes      |
 
-### 1.13. List
+### 1.12. List
 
 List serialization is of variable size.
 
@@ -146,7 +134,7 @@ List serialization is of variable size.
 | 0              |  4                       | *len* = number of list elements |
 | 4              |  *sum(len(serialize_N))* | serialize_N(T) byte array       |
 
-### 1.14. Optional
+### 1.13. Optional
 
 Optional serialization is of variable size.
 
@@ -154,7 +142,7 @@ Optional serialization is of variable size.
 |----------------|--------------------------|---------------------------------|
 | 0              |  1                       | 0, if the value is not present, 1 otherwise |
 
-### 1.15. Enum
+### 1.14. Enum
 
 Enum serialization is always of a constant size (4 bytes).
 


### PR DESCRIPTION
Solution: do not define "char" at all, if using utf8.
It's not a byte, nor a code point nor a grapheme cluster.
ht to @cryptocompress
