### PR TITLE
Problem: Node.js modules from gitbook might leak into the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _book
+node_modules


### PR DESCRIPTION
Solution: add node_modules to .gitignore
