### PR TITLE
Problem: binary as a hexadecimal number can be misinterpreted

### DIFF
--- a/5/README.md
+++ b/5/README.md
@@ -71,7 +71,7 @@ Serialized as an usigned integer number, 0..255
 
 ### 2.9. ByteArray
 
-Serialized as a hexadecimal number
+Serialized as a base64 string
 
 ### 2.10. String
 


### PR DESCRIPTION
Byte order can be misinterpreted; theoretically, a YAML implementation
might not support big integers and therefore not be able to process
larger binaries.

Solution: use base64 instead.
