### PR TITLE
Problem: hard to find the latest version of a given spec

### DIFF
--- a/book.js
+++ b/book.js
@@ -3,5 +3,5 @@ var fs = require('fs');
 module.exports = {
     title: 'Eventsourcing RFCs',
     gitbook: '>=3.0.0',
-    plugins: ['coss@1.0.5']
+    plugins: ['coss@1.0.6']
 };


### PR DESCRIPTION
Solution: new COSS plugin version creates a shortcut (like /ELF)
