### PR TITLE
Problem: EventCausalityEstablished only done for migrations is incomplete

### DIFF
--- a/8/README.md
+++ b/8/README.md
@@ -69,23 +69,11 @@ This event describes a replacement of an entity layout with a new one. Old
 layout's fingerprint MUST be recorded in `fingerprint`, and a corresponding
 `EntityLayoutIntroduced`'s UUID MUST be recorded in `replacement`.
 
-#### 1.1.3. EventCausalityEstablished <a name="EventCausalityEstablished"></a>
-
-Layout name: `rfc.eventsourcing.com/spec:8/EMT/#EventCausalityEstablished`
-
-| Type | Property |
-|------|----------|
-| UUID | event    |
-| UUID | command  |
-
-When event replacement happens, event->command causality is lost and for some types of applications it means information loss. In order to mitigate this, *EventCausalityEstablished* signals an establishment of a new causality relationship for an event. Repository's journal SHOULD use this type of event
-to establish this relationship internally.
-
 ## 2. Transformation
 
 ### 2.1. Events
 
-A migration command SHOULD process events referenced by `EntityLayoutIntroduced.previousFingerprint` and MAY produce new corresponding events with fingerprints referenced by `EntityLayoutIntroduced.fingerprint`.
+When event replacement happens, event->command causality is lost and for some types of applications it means information loss. In order to mitigate this, [EventCausalityEstablished](http://rfc.eventsourcing.com/spec:9/RIG/#EventCausalityEstablished) signals an establishment of a new causality relationship for an event.
 
 ### 2.2. Commands
 

--- a/9/README.md
+++ b/9/README.md
@@ -80,6 +80,16 @@ For every event E<sub>k</sub>, repository MUST perform the following operations:
 1. Record E<sub>k</sub> and associate it with command C.
 1. Index E<sub>k</sub> (see [5. Indexing and Querying](../9/README.md#indexing-and-querying)).
 1. Check if there any parties interested in this event should Tx<sub>C</sub> successfuly commit (*entity subscribers*). If there are any, E<sub>k</sub>  should be associated with these matching entity subscribers.
+1. Record a corresponding `EventCausalityEstablished` event establishing a causal relationship between command C and event E<sub><k/sub>
+
+Layout name: `rfc.eventsourcing.com/spec:9/RIG/#EventCausalityEstablished`
+
+| Type | Property |
+|------|----------|
+| UUID | event    |
+| UUID | command  |
+
+Repository MAY record [EntityLayoutIntroduced](../9/README.md#EntityLayoutIntroduced) when it first encounters a new layout.
 
 <a name="CommandTerminatedExceptionally"></a> If at any time during event collection, an exception is raised (or an equivalent of such), repository MUST remove all recorded events and replace it with a `CommandTerminatedExceptionally` event:
 


### PR DESCRIPTION
It makes it harder to query for actual causal relationship between
events and commands for events that were never migrated.

Solution: EventCausalityEstablished must be created for all events
