### PR TITLE
Problem: No support for BigInteger

### DIFF
--- a/1/README.md
+++ b/1/README.md
@@ -62,45 +62,51 @@ mirrors the definition of Java's BigDecimal.
 
 Default value: `0`
 
-### 1.6. Float
+### 1.6. BigInteger
 
-Default value: `0.0`
-
-### 1.7. Double
-
-Default value: `0.0`
-
-### 1.8. Byte
+BigDecimal is an arbitrary precision integer.
 
 Default value: `0`
 
-### 1.9. ByteArray
+### 1.7. Float
+
+Default value: `0.0`
+
+### 1.8. Double
+
+Default value: `0.0`
+
+### 1.9. Byte
+
+Default value: `0`
+
+### 1.10. ByteArray
 
 ByteArray is an array of bytes.
 
 Default value: empty array.
 
-### 1.10. String
+### 1.11. String
 
 UTF-8 string.
 
 Default value: empty string
 
-### 1.11. UUID
+### 1.12. UUID
 
 Default value: `00000000-0000-0000-0000-000000000000`
 
-### 1.12. Timestamp
+### 1.13. Timestamp
 
 Default value: January 1, 1970, 00:00:00 GMT
 
-### 1.13. List
+### 1.14. List
 
 List is a parametrized type and can take any other type as a parameter.
 
 Default value: empty list
 
-### 1.14. Optional
+### 1.15. Optional
 
 Optional is a type that signifies a value that might be either present or not.
 
@@ -108,21 +114,21 @@ Optional is a parametrized type and can take any other type as a parameter.
 
 Default value: value not present
 
-### 1.15. Enum
+### 1.16. Enum
 
 Enum represents a type with a closed set of possible ordinal (integer) values (for example, `OPEN = 0, CLOSED = 1`). The ordinal values MUST start with 0
 and form a consecutive sequence.
 
 Default value: smallest ordinal value (0).
 
-### 1.16. Map
+### 1.17. Map
 
 Map represents a collection of (key, value) pairs, such that each possible
 key appears at most once in the collection.
 
 Default value: an empty map.
 
-### 1.17. Object
+### 1.18. Object
 
 See [3. Object](../1/README.md#object) for the definition.
 
@@ -144,6 +150,7 @@ It is RECOMMENDED that a human readable, latin1 encoded name is specified for ty
 | Integer       | 0x496e7465676572              | Integer                       |
 | Long          | 0x4c6f6e67                    | Long                          |
 | BigDecimal    | 0x426967446563696d616c        | BigDecimal                    |
+| BigInteger    | 0x426967496e7465676572        | BigInteger                    |
 | Float         | 0x466c6f6174                  | Float                         |
 | Double        | 0x446f75626c65                | Double                        |
 | Byte          | 0x42797465                    | Byte                          |

--- a/2/README.md
+++ b/2/README.md
@@ -75,7 +75,16 @@ BigDecimal serialization is of a variable size.
 
 The unscaled value is the The unscaled will contain the minimum number of bytes required to represent the value, including at least one sign bit.
 
-### 1.6. Float
+### 1.6. BigInteger
+
+BigInteger serialization is of a variable size.
+
+| Offset (bytes) | Length (bytes) | Value                                |
+|----------------|----------------|--------------------------------------|
+| 0              |  4             | *len* = length                       |
+| 4              |  *len*         | value                                |
+
+### 1.7. Float
 
 Float serialization is always of a constant size (4 bytes).
 
@@ -83,7 +92,7 @@ Float serialization is always of a constant size (4 bytes).
 |----------------|----------------|----------------------------|
 | 0              |  4             | float value                |
 
-### 1.7. Double
+### 1.8. Double
 
 Double serialization is always of a constant size (8 bytes).
 
@@ -91,7 +100,7 @@ Double serialization is always of a constant size (8 bytes).
 |----------------|----------------|----------------------------|
 | 0              |  8             | double value               |
 
-### 1.8. Byte
+### 1.9. Byte
 
 Byte serialization is always of a constant size (1 bytes).
 
@@ -99,7 +108,7 @@ Byte serialization is always of a constant size (1 bytes).
 |----------------|----------------|----------------------------|
 | 0              |  1             | byte value                 |
 
-### 1.9. ByteArray
+### 1.10. ByteArray
 
 ByteArray is an array of bytes.
 
@@ -110,7 +119,7 @@ ByteArray serialization is of a variable size.
 | 0              |  4             | *len* = number of bytes    |
 | 4              |  *len*         | bytes                      |
 
-### 1.10. String
+### 1.11. String
 
 String serialization is of variable size.
 
@@ -119,7 +128,7 @@ String serialization is of variable size.
 | 0              |  4             | *len* = string size in bytes |
 | 4              |  *len*         | UTF-8 encoded string         |
 
-### 1.11. UUID
+### 1.12. UUID
 
 UUID serialization is always of a constant size (16 bytes)
 
@@ -128,7 +137,7 @@ UUID serialization is always of a constant size (16 bytes)
 | 0              |  8             | most significant bytes       |
 | 8              |  8             | least significant bytes      |
 
-### 1.12. Timestamp
+### 1.13. Timestamp
 
 Timestamp serialization is always of a constant size (8 bytes)
 
@@ -136,7 +145,7 @@ Timestamp serialization is always of a constant size (8 bytes)
 |----------------|----------------|------------------------------|
 | 0              |  8             | number of milliseconds since January 1, 1970, 00:00:00 GMT |
 
-### 1.13. List
+### 1.14. List
 
 List serialization is of variable size.
 
@@ -145,7 +154,7 @@ List serialization is of variable size.
 | 0              |  4                       | *len* = number of list elements |
 | 4              |  *sum(len(serialize_N))* | serialize_N(T) byte array       |
 
-### 1.14. Optional
+### 1.15. Optional
 
 Optional serialization is of variable size.
 
@@ -154,7 +163,7 @@ Optional serialization is of variable size.
 | 0              |  1                       | 0, if the value is not present, 1 otherwise |
 | 1              |  ?                       | For Optional[T], binary encoding of T |
 
-### 1.15. Enum
+### 1.16. Enum
 
 Enum serialization is always of a constant size (4 bytes).
 
@@ -162,7 +171,7 @@ Enum serialization is always of a constant size (4 bytes).
 |----------------|----------------|----------------------------|
 | 0              |  4             | ordinal (integer) value    |
 
-### 1.16. Map
+### 1.17. Map
 
 Map serialization is of variable size.
 

--- a/5/README.md
+++ b/5/README.md
@@ -57,39 +57,43 @@ Serialized as a signed integer number, –9223372036854775808 to 922337203685477
 
 Serialized as a floating point number, no limits.
 
-### 2.6. Float
+### 2.6. BigInteger
+
+Serialized as an integer, no limits.
+
+### 2.7. Float
 
 Serialized as a floating point number, 3.4E +/- 38 (7 digits)
 
-### 2.7. Double
+### 2.8. Double
 
 Serialized as a floating point number, 1.7E +/- 308 (15 digits)
 
-### 2.8. Byte
+### 2.9. Byte
 
 Serialized as an usigned integer number, 0..255
 
-### 2.9. ByteArray
+### 2.10. ByteArray
 
 Serialized as a base64 string
 
-### 2.10. String
+### 2.11. String
 
 Serialized as a string
 
-### 2.11. UUID
+### 2.12. UUID
 
 Serialized as a canonical UUID string representation, `"xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx"`
 
-### 2.12. Timestamp
+### 2.13. Timestamp
 
 Serialized as a number of milliseconds since January 1, 1970, 00:00:00 GMT
 
-### 2.13. List
+### 2.14. List
 
 Serialized as a JSON list
 
-### 2.14. Optional
+### 2.15. Optional
 
 Serialized as an empty map for non-present values:
 
@@ -103,12 +107,12 @@ Serialized as a map with `present` key for present values:
 {"present": <value>}
 ```
 
-### 2.15. Enum
+### 2.16. Enum
 
 Serialized as a string value associated with the ordinal value. If
 string value is absent, the ordinal value integer is used.
 
-### 2.16. Map
+### 2.17. Map
 
 Serialized as a JSON list of two-elements lists:
 


### PR DESCRIPTION
While it can be simulated with BigDecimal, it isn't optimal (extra storage
requirements, additional conversion complexity in target languages)

Solution: introduce BigInteger type